### PR TITLE
テーブルからレコードを全件取得するAPI実装後、クエリ文字列を指定して検索するAPIも実装

### DIFF
--- a/src/main/java/com/sakashita/nameapp/Name.java
+++ b/src/main/java/com/sakashita/nameapp/Name.java
@@ -1,0 +1,20 @@
+package com.sakashita.nameapp;
+
+public class Name {
+    private Integer id;
+
+    private String name;
+
+    public Name(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+}

--- a/src/main/java/com/sakashita/nameapp/NameController.java
+++ b/src/main/java/com/sakashita/nameapp/NameController.java
@@ -1,0 +1,23 @@
+package com.sakashita.nameapp;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class NameController {
+
+    private NameMapper nameMapper;
+
+    public NameController(NameMapper nameMapper) {
+        this.nameMapper = nameMapper;
+    }
+
+    @GetMapping("/names")
+    public List<Name> getNames(@RequestParam String startsWith) {
+        List<Name> names = nameMapper.findByNameStartsWith(startsWith);
+        return names;
+    }
+}

--- a/src/main/java/com/sakashita/nameapp/NameMapper.java
+++ b/src/main/java/com/sakashita/nameapp/NameMapper.java
@@ -1,0 +1,16 @@
+package com.sakashita.nameapp;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+
+@Mapper
+public interface NameMapper {
+
+    @Select("SELECT * FROM names")
+    List<Name> findAll();
+
+    @Select("SELECT * FROM names WHERE name LIKE CONCAT(#{startsWith}, '%')")
+    List<Name> findByNameStartsWith(String startsWith);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=nameapp
+spring.datasource.url=jdbc:mysql://localhost:3307/name_database
+spring.datasource.username=user
+spring.datasource.password=password


### PR DESCRIPTION
# テーブルからレコードを全件取得するAPI
初期テーブルに"ueda"と"sakashita"を追加後にレコードを全件取得しました。

![スクリーンショット 2024-07-15 174156](https://github.com/user-attachments/assets/df83709c-afbb-4282-8c32-fed16872771e)
初期状態

![スクリーンショット 2024-07-15 174613](https://github.com/user-attachments/assets/b8c7987d-2c9c-46ad-8272-b2a56949ee04)
"ueda"と"sakashita"を追加

![スクリーンショット 2024-07-15 174636](https://github.com/user-attachments/assets/61606820-2d18-4220-94a9-4de81576fcf4)
全件取得されていることを確認

# クエリ文字列を指定して検索するAPI
"u"から始まる名前を取得するAPIを実装しました。

![スクリーンショット 2024-07-15 192214](https://github.com/user-attachments/assets/7d0e0915-116b-4751-a577-6c6c53f49172)
先ほど追加した"ueda"が取得されていることを確認